### PR TITLE
Rename NuGet packages to FFmpegKit.Net

### DIFF
--- a/.github/scripts/run-device-tests.sh
+++ b/.github/scripts/run-device-tests.sh
@@ -41,7 +41,7 @@ printf '{ "sdk": { "version": "%s", "rollForward": "latestFeature" } }\n' "${sdk
 # NuGet caches by package id + version, so rebuilding a version that was already restored once
 # silently reuses the stale copy. CI versions are unique, but locally you will re-pack the same
 # version repeatedly and test yesterday's bits without this.
-package_id="xamarin.ffmpegkit.$(printf '%s' "${VARIANT}" | tr '[:upper:]' '[:lower:]').android"
+package_id="ffmpegkit.net.$(printf '%s' "${VARIANT}" | tr '[:upper:]' '[:lower:]').android"
 rm -rf "${HOME}/.nuget/packages/${package_id}/${VERSION}"
 
 echo "==> installing device tests (variant=${VARIANT}, version=${VERSION}, tfm=${TARGET_FRAMEWORK}, sdk=${sdk_version})"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -88,7 +88,7 @@ jobs:
             echo "### Published \`${{ needs.version.outputs.version }}\` to nuget.org"
             echo
             for variant in Audio Full FullGpl Https HttpsGpl Min MinGpl Video; do
-              id="Xamarin.FFmpegKit.${variant}.Android"
+              id="FFmpegKit.Net.${variant}.Android"
               echo "- [${id}](https://www.nuget.org/packages/${id}/${{ needs.version.outputs.version }})"
             done
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
             echo "| Package | License | NuGet |"
             echo "| --- | --- | --- |"
             for variant in Audio Full FullGpl Https HttpsGpl Min MinGpl Video; do
-              id="Xamarin.FFmpegKit.${variant}.Android"
+              id="FFmpegKit.Net.${variant}.Android"
               case "${variant}" in
                 *Gpl) license="MIT AND GPL-3.0-only" ;;
                 *)    license="MIT AND LGPL-3.0-only" ;;
@@ -133,7 +133,7 @@ jobs:
             done
             echo
             echo "\`\`\`"
-            echo "dotnet add package Xamarin.FFmpegKit.Video.Android --version ${VERSION}"
+            echo "dotnet add package FFmpegKit.Net.Video.Android --version ${VERSION}"
             echo "\`\`\`"
             echo
             echo "## Licensing"

--- a/FFmpegKit.Android.Example/FFmpegKit.Android.Example.csproj
+++ b/FFmpegKit.Android.Example/FFmpegKit.Android.Example.csproj
@@ -50,7 +50,7 @@
       does not come from nuget.org, so the example exercises what you just built.
       Full is the LGPL variant; the -gpl ones would make this sample GPL-3.0.
     -->
-    <PackageReference Include="Xamarin.FFmpegKit.Full.Android" Version="$(FFmpegKitVersion)" />
+    <PackageReference Include="FFmpegKit.Net.Full.Android" Version="$(FFmpegKitVersion)" />
   </ItemGroup>
 
 </Project>

--- a/FFmpegKit.Android.Example/MainPage.xaml
+++ b/FFmpegKit.Android.Example/MainPage.xaml
@@ -15,7 +15,7 @@
                 SemanticProperties.HeadingLevel="Level1" />
 
             <Label
-                Text="Pick a conversion, run it with the Xamarin.FFmpegKit.Full.Android NuGet package, and compare the result to the original."
+                Text="Pick a conversion, run it with the FFmpegKit.Net.Full.Android NuGet package, and compare the result to the original."
                 Style="{StaticResource SubHeadline}" />
 
             <Label Text="Conversion type" FontAttributes="Bold" />

--- a/FFmpegKit.Android/FFmpegKit.Android.csproj
+++ b/FFmpegKit.Android/FFmpegKit.Android.csproj
@@ -19,8 +19,15 @@
     -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <CheckEolWorkloads>false</CheckEolWorkloads>
+    <!--
+      The namespace stays Ffmpegkit.Droid even though the package is now FFmpegKit.Net.*. A
+      namespace rooted at "FFmpegKit" containing a type also called FFmpegKit makes every
+      consumer call ambiguous - `FFmpegKit.Execute(...)` resolves the namespace first and fails
+      with "'Execute' does not exist in the namespace 'FFmpegKit'". Renaming it is a breaking
+      source change that would buy nothing.
+    -->
     <RootNamespace>Ffmpegkit.Droid</RootNamespace>
-    <AssemblyName>FFmpegKit.$(FFmpegKitBuildType).Android</AssemblyName>
+    <AssemblyName>FFmpegKit.Net.$(FFmpegKitBuildType).Android</AssemblyName>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -90,11 +97,11 @@
   <!-- Packaging -->
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <PackageId>Xamarin.FFmpegKit.$(FFmpegKitBuildType).Android</PackageId>
-    <Title>Xamarin bindings to the native Android FFmpegKit $(FFmpegKitBuildType) SDK.</Title>
-    <Description>Xamarin bindings to the native FFmpegKit $(FFmpegKitBuildType) SDK. Built against FFmpegKit $(FFmpegKitNativeVersion) for .NET for Android. The bundled native FFmpeg binaries are licensed under $(FFmpegKitNativeLicense); the binding code is MIT. See the licence files in this package before shipping.</Description>
+    <PackageId>FFmpegKit.Net.$(FFmpegKitBuildType).Android</PackageId>
+    <Title>.NET for Android bindings for the native FFmpegKit $(FFmpegKitBuildType) SDK.</Title>
+    <Description>.NET for Android / .NET MAUI bindings for the native FFmpegKit $(FFmpegKitBuildType) SDK. Built against FFmpegKit $(FFmpegKitNativeVersion). The bundled native FFmpeg binaries are licensed under $(FFmpegKitNativeLicense); the binding code is MIT. See the licence files in this package before shipping.</Description>
     <PackageLicenseExpression>MIT AND $(FFmpegKitNativeLicense)</PackageLicenseExpression>
-    <PackageTags>ffmpeg;ffmpegkit;$(FFmpegKitAarName);video;audio;SDK;Xamarin;Android;Xamarin.Android;MAUI;Binding</PackageTags>
+    <PackageTags>ffmpeg;ffmpegkit;$(FFmpegKitAarName);video;audio;transcode;SDK;MAUI;Android;dotnet-android;Binding</PackageTags>
     <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <IncludeSymbols>true</IncludeSymbols>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 .NET for Android and .NET MAUI bindings for the native **FFmpegKit** library.
 
-Original project: **[arthenica/ffmpeg-kit-next](https://github.com/arthenica/ffmpeg-kit-next)**
+Built against the prebuilt Android binaries from **[ffmpegkit-maintained/ffmpeg](https://github.com/ffmpegkit-maintained/ffmpeg)** — see [Where the native binaries come from](#where-the-native-binaries-come-from) for why that fork and not the original.
 
 ## About
 
@@ -16,7 +16,17 @@ Each .NET SDK's Android workload supports only two target frameworks — the .NE
 
 ### Where the native binaries come from
 
-The original `arthenica/ffmpeg-kit` repository is archived and its `v5.1.LTS` release assets have been deleted; its successor `ffmpeg-kit-next` is source-only. The `.aar` files are therefore pulled from the community-maintained Maven Central mirror `dev.ffmpegkit-maintained` — see [`FetchJars.sh`](FFmpegKit.Android/Jars/FetchJars.sh). The version is set by `FFmpegKitNativeVersion` in [`Directory.Build.props`](Directory.Build.props), which `FetchJars.sh` reads, so the download and the `.aar` the project expects cannot drift apart.
+FFmpegKit has three relevant repositories, and only one of them still ships usable Android binaries:
+
+| Repository | State | Prebuilt `.aar` |
+| --- | --- | --- |
+| [`arthenica/ffmpeg-kit`](https://github.com/arthenica/ffmpeg-kit) | archived | none — the `v5.1.LTS` release assets were deleted; Maven Central stops at `6.0.LTS` |
+| [`arthenica/ffmpeg-kit-next`](https://github.com/arthenica/ffmpeg-kit-next) | active, the official continuation | none — releases up to `v8.1.0` carry source only, zero binary assets |
+| [`ffmpegkit-maintained/ffmpeg`](https://github.com/ffmpegkit-maintained/ffmpeg) | active community fork | **yes** — published to Maven Central as `dev.ffmpegkit-maintained`, currently `8.1.7` |
+
+So the `.aar` files come from the community fork, via Maven Central — see [`FetchJars.sh`](FFmpegKit.Android/Jars/FetchJars.sh). It keeps the original `com.arthenica.ffmpegkit` Java API, so the binding and its `Ffmpegkit.Droid` namespace are unaffected by the switch. Should `ffmpeg-kit-next` start publishing binaries, moving over would be a change to `FetchJars.sh` and `FFmpegKitNativeVersion` only.
+
+The version is set by `FFmpegKitNativeVersion` in [`Directory.Build.props`](Directory.Build.props), which `FetchJars.sh` reads, so the download and the `.aar` the project expects cannot drift apart.
 
 `FFmpegKitConfig` also needs the two `smart-exception` jars at runtime. They are not bundled in the `.aar` and not declared in its `.pom`, so they are fetched separately and embedded into the binding.
 
@@ -87,7 +97,7 @@ Execute your FFmpeg command
 FFmpegKit.Execute("-i input.mov -c:v libx264 output.mp4");
 ```
 
-More examples and usage can be found in the [FFmpegKit wiki](https://github.com/arthenica/ffmpeg-kit/wiki/Android).
+More examples and usage can be found in the [original FFmpegKit wiki](https://github.com/arthenica/ffmpeg-kit/wiki/Android). That repository is archived, but the Java API it documents is the one these bindings expose, so it remains the reference.
 
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > ⚠️ **This project is under active development.** APIs, repository structure, and NuGet packages may change without notice. Use in production at your own risk.
 
-Xamarin/.NET for Android bindings for the native **FFmpegKit** library.
+.NET for Android and .NET MAUI bindings for the native **FFmpegKit** library.
 
 Original project: **[arthenica/ffmpeg-kit-next](https://github.com/arthenica/ffmpeg-kit-next)**
 
@@ -16,7 +16,7 @@ Each .NET SDK's Android workload supports only two target frameworks — the .NE
 
 ### Where the native binaries come from
 
-The original `arthenica/ffmpeg-kit` repository is archived and its `v5.1.LTS` release assets have been deleted; its successor `ffmpeg-kit-next` is source-only. The `.aar` files are therefore pulled from the community-maintained Maven Central mirror `dev.ffmpegkit-maintained` — see [`FetchJars.sh`](FFmpegKit.Android/Jars/FetchJars.sh). The version is set by `FFmpegKitNativeVersion` in [`Directory.Build.props`](Directory.Build.props), and `FetchJars.sh` must be kept in sync with it.
+The original `arthenica/ffmpeg-kit` repository is archived and its `v5.1.LTS` release assets have been deleted; its successor `ffmpeg-kit-next` is source-only. The `.aar` files are therefore pulled from the community-maintained Maven Central mirror `dev.ffmpegkit-maintained` — see [`FetchJars.sh`](FFmpegKit.Android/Jars/FetchJars.sh). The version is set by `FFmpegKitNativeVersion` in [`Directory.Build.props`](Directory.Build.props), which `FetchJars.sh` reads, so the download and the `.aar` the project expects cannot drift apart.
 
 `FFmpegKitConfig` also needs the two `smart-exception` jars at runtime. They are not bundled in the `.aar` and not declared in its `.pom`, so they are fetched separately and embedded into the binding.
 
@@ -28,14 +28,14 @@ The C# binding code in this repository is [MIT](LICENSE). **The published NuGet 
 
 | Package | Native license | SPDX expression |
 | --- | --- | --- |
-| `Xamarin.FFmpegKit.Audio.Android` | LGPL-3.0 | `MIT AND LGPL-3.0-only` |
-| `Xamarin.FFmpegKit.Full.Android` | LGPL-3.0 | `MIT AND LGPL-3.0-only` |
-| `Xamarin.FFmpegKit.Https.Android` | LGPL-3.0 | `MIT AND LGPL-3.0-only` |
-| `Xamarin.FFmpegKit.Min.Android` | LGPL-3.0 | `MIT AND LGPL-3.0-only` |
-| `Xamarin.FFmpegKit.Video.Android` | LGPL-3.0 | `MIT AND LGPL-3.0-only` |
-| `Xamarin.FFmpegKit.FullGpl.Android` | **GPL-3.0** | `MIT AND GPL-3.0-only` |
-| `Xamarin.FFmpegKit.HttpsGpl.Android` | **GPL-3.0** | `MIT AND GPL-3.0-only` |
-| `Xamarin.FFmpegKit.MinGpl.Android` | **GPL-3.0** | `MIT AND GPL-3.0-only` |
+| `FFmpegKit.Net.Audio.Android` | LGPL-3.0 | `MIT AND LGPL-3.0-only` |
+| `FFmpegKit.Net.Full.Android` | LGPL-3.0 | `MIT AND LGPL-3.0-only` |
+| `FFmpegKit.Net.Https.Android` | LGPL-3.0 | `MIT AND LGPL-3.0-only` |
+| `FFmpegKit.Net.Min.Android` | LGPL-3.0 | `MIT AND LGPL-3.0-only` |
+| `FFmpegKit.Net.Video.Android` | LGPL-3.0 | `MIT AND LGPL-3.0-only` |
+| `FFmpegKit.Net.FullGpl.Android` | **GPL-3.0** | `MIT AND GPL-3.0-only` |
+| `FFmpegKit.Net.HttpsGpl.Android` | **GPL-3.0** | `MIT AND GPL-3.0-only` |
+| `FFmpegKit.Net.MinGpl.Android` | **GPL-3.0** | `MIT AND GPL-3.0-only` |
 
 The `-gpl` variants enable `x264`, `x265`, `xvid` and `vidstab`, which are GPL — upstream keeps them as separate artifacts specifically so they never contaminate the LGPL ones. Upstream's guidance is direct: **if your app is closed-source, use a non-GPL variant.**
 
@@ -49,15 +49,30 @@ Install the package via NuGet. There are various packages depending on what you 
 
 | Package | Link|
 |------------|-----|
-| Xamarin.FFmpegKit.Audio.Android   | [![NuGet](https://img.shields.io/nuget/vpre/Xamarin.FFmpegKit.Audio.Android.svg?label=NuGet)](https://www.nuget.org/packages/Xamarin.FFmpegKit.Audio.Android) |
-| Xamarin.FFmpegKit.Full.Android   | [![NuGet](https://img.shields.io/nuget/vpre/Xamarin.FFmpegKit.Full.Android.svg?label=NuGet)](https://www.nuget.org/packages/Xamarin.FFmpegKit.Full.Android) |
-| Xamarin.FFmpegKit.FullGpl.Android   | [![NuGet](https://img.shields.io/nuget/vpre/Xamarin.FFmpegKit.FullGpl.Android.svg?label=NuGet)](https://www.nuget.org/packages/Xamarin.FFmpegKit.FullGpl.Android) |
-| Xamarin.FFmpegKit.Https.Android   | [![NuGet](https://img.shields.io/nuget/vpre/Xamarin.FFmpegKit.Https.Android.svg?label=NuGet)](https://www.nuget.org/packages/Xamarin.FFmpegKit.Https.Android) |
-| Xamarin.FFmpegKit.HttpsGpl.Android   | [![NuGet](https://img.shields.io/nuget/vpre/Xamarin.FFmpegKit.HttpsGpl.Android.svg?label=NuGet)](https://www.nuget.org/packages/Xamarin.FFmpegKit.HttpsGpl.Android) |
-| Xamarin.FFmpegKit.Min.Android   | [![NuGet](https://img.shields.io/nuget/vpre/Xamarin.FFmpegKit.Min.Android.svg?label=NuGet)](https://www.nuget.org/packages/Xamarin.FFmpegKit.Min.Android) |
-| Xamarin.FFmpegKit.MinGpl.Android   | [![NuGet](https://img.shields.io/nuget/vpre/Xamarin.FFmpegKit.MinGpl.Android.svg?label=NuGet)](https://www.nuget.org/packages/Xamarin.FFmpegKit.MinGpl.Android) |
-| Xamarin.FFmpegKit.Video.Android   | [![NuGet](https://img.shields.io/nuget/vpre/Xamarin.FFmpegKit.Video.Android.svg?label=NuGet)](https://www.nuget.org/packages/Xamarin.FFmpegKit.Video.Android) |
+| FFmpegKit.Net.Audio.Android   | [![NuGet](https://img.shields.io/nuget/vpre/FFmpegKit.Net.Audio.Android.svg?label=NuGet)](https://www.nuget.org/packages/FFmpegKit.Net.Audio.Android) |
+| FFmpegKit.Net.Full.Android   | [![NuGet](https://img.shields.io/nuget/vpre/FFmpegKit.Net.Full.Android.svg?label=NuGet)](https://www.nuget.org/packages/FFmpegKit.Net.Full.Android) |
+| FFmpegKit.Net.FullGpl.Android   | [![NuGet](https://img.shields.io/nuget/vpre/FFmpegKit.Net.FullGpl.Android.svg?label=NuGet)](https://www.nuget.org/packages/FFmpegKit.Net.FullGpl.Android) |
+| FFmpegKit.Net.Https.Android   | [![NuGet](https://img.shields.io/nuget/vpre/FFmpegKit.Net.Https.Android.svg?label=NuGet)](https://www.nuget.org/packages/FFmpegKit.Net.Https.Android) |
+| FFmpegKit.Net.HttpsGpl.Android   | [![NuGet](https://img.shields.io/nuget/vpre/FFmpegKit.Net.HttpsGpl.Android.svg?label=NuGet)](https://www.nuget.org/packages/FFmpegKit.Net.HttpsGpl.Android) |
+| FFmpegKit.Net.Min.Android   | [![NuGet](https://img.shields.io/nuget/vpre/FFmpegKit.Net.Min.Android.svg?label=NuGet)](https://www.nuget.org/packages/FFmpegKit.Net.Min.Android) |
+| FFmpegKit.Net.MinGpl.Android   | [![NuGet](https://img.shields.io/nuget/vpre/FFmpegKit.Net.MinGpl.Android.svg?label=NuGet)](https://www.nuget.org/packages/FFmpegKit.Net.MinGpl.Android) |
+| FFmpegKit.Net.Video.Android   | [![NuGet](https://img.shields.io/nuget/vpre/FFmpegKit.Net.Video.Android.svg?label=NuGet)](https://www.nuget.org/packages/FFmpegKit.Net.Video.Android) |
 
+
+### Migrating from `Xamarin.FFmpegKit.*`
+
+These packages replace the `Xamarin.FFmpegKit.*.Android` ones, which are no longer published. Change the package id and nothing else:
+
+```diff
+-<PackageReference Include="Xamarin.FFmpegKit.Video.Android" Version="4.5.1" />
++<PackageReference Include="FFmpegKit.Net.Video.Android" Version="8.1.7" />
+```
+
+**The `Ffmpegkit.Droid` namespace is unchanged**, so your `using` directives and calls stay as they are. It deliberately does not follow the package name: a namespace rooted at `FFmpegKit` containing a type also called `FFmpegKit` makes `FFmpegKit.Execute(...)` resolve the namespace instead of the class and fail to compile.
+
+The assembly is now `FFmpegKit.Net.<Variant>.Android` (was `FFmpegKit.<Variant>.Android`), which matters only if you reference it by assembly name or use reflection.
+
+Note that the native library also moved on from the archived `arthenica` builds — see [Where the native binaries come from](#where-the-native-binaries-come-from) — so upgrading from `4.5.1` is a jump from FFmpegKit 4.5 to 8.1.7, not just a repackaging.
 
 ## Usage
 
@@ -139,7 +154,7 @@ Arguments are the variant, the package version in `./artifacts`, and which of th
 dotnet build FFmpegKit.Android.Example -t:Install     # deploy to a running device/emulator
 ```
 
-It resolves `Xamarin.FFmpegKit.Full.Android` from `./artifacts` through the local feed in `NuGet.config`, **not** from nuget.org, so it always exercises your local build. The version defaults to `FFmpegKitNativeVersion`; pass `-p:FFmpegKitVersion=8.1.7-rc.1` to point it at a specific build.
+It resolves `FFmpegKit.Net.Full.Android` from `./artifacts` through the local feed in `NuGet.config`, **not** from nuget.org, so it always exercises your local build. The version defaults to `FFmpegKitNativeVersion`; pass `-p:FFmpegKitVersion=8.1.7-rc.1` to point it at a specific build.
 
 It references the `Full` (LGPL) variant deliberately — swapping to a `-gpl` one would make the sample itself GPL-3.0.
 

--- a/tests/FFmpegKit.Android.DeviceTests/FFmpegKit.Android.DeviceTests.csproj
+++ b/tests/FFmpegKit.Android.DeviceTests/FFmpegKit.Android.DeviceTests.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.FFmpegKit.$(FFmpegKitVariant).Android" Version="$(FFmpegKitPackageVersion)" />
+    <PackageReference Include="FFmpegKit.Net.$(FFmpegKitVariant).Android" Version="$(FFmpegKitPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/tests/FFmpegKit.Android.PackageTests/PackageFixture.cs
+++ b/tests/FFmpegKit.Android.PackageTests/PackageFixture.cs
@@ -32,7 +32,7 @@ public static class Packages
             : AllVariants)
         .Select(v => new object[] { v });
 
-    public static string PackageId(string variant) => $"Xamarin.FFmpegKit.{variant}.Android";
+    public static string PackageId(string variant) => $"FFmpegKit.Net.{variant}.Android";
 
     /// <summary>
     /// Upstream ships the -gpl variants under GPL-3.0 and the rest under LGPL-3.0. Getting this
@@ -44,7 +44,7 @@ public static class Packages
 
     public static string LicenseExpression(string variant) => $"MIT AND {NativeLicense(variant)}";
 
-    public static string AssemblyName(string variant) => $"FFmpegKit.{variant}.Android";
+    public static string AssemblyName(string variant) => $"FFmpegKit.Net.{variant}.Android";
 
     /// <summary>FullGpl -> full-gpl, HttpsGpl -> https-gpl, Video -> video, ...</summary>
     public static string AarName(string variant) => variant.ToLowerInvariant().Replace("gpl", "-gpl");


### PR DESCRIPTION
Updates package IDs, assembly names, and documentation to align with the modern .NET ecosystem, including .NET MAUI.

The `Ffmpegkit.Droid` namespace is intentionally kept unchanged to maintain source compatibility and avoid compilation issues with an identically named class.

A migration guide has been added to the README for existing users.