### PR TITLE
Implement curated release notes in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,13 +103,26 @@ jobs:
           native=$(grep -oPm1 '(?<=<FFmpegKitNativeVersion>)[^<]+' Directory.Build.props)
           previous=$(git describe --tags --abbrev=0 "${GITHUB_REF_NAME}^" 2>/dev/null || true)
 
+          # A curated docs/release-notes/<version>.md replaces the generated commit list when one
+          # exists. The second lookup drops the prerelease suffix, so v8.1.7-beta.2 reuses the
+          # notes written for 8.1.7 rather than silently falling back to raw commit subjects.
+          notes="docs/release-notes/${VERSION}.md"
+          [ -f "${notes}" ] || notes="docs/release-notes/${VERSION%%-*}.md"
+
           {
-            echo "## What's changed"
-            echo
-            if [ -n "${previous}" ]; then
-              git log --no-merges --pretty='- %s (%h)' "${previous}..${GITHUB_REF_NAME}"
+            if [ -f "${notes}" ]; then
+              echo "==> using curated notes from ${notes}" >&2
+              cat "${notes}"
             else
-              git log --no-merges --pretty='- %s (%h)' "${GITHUB_REF_NAME}"
+              echo "## What's changed"
+              echo
+              if [ -n "${previous}" ]; then
+                git log --no-merges --pretty='- %s (%h)' "${previous}..${GITHUB_REF_NAME}"
+              else
+                # No previous tag: listing every commit would reach back to the repository's
+                # first commit, which is noise rather than a changelog.
+                echo "Initial release."
+              fi
             fi
             echo
             if [ -n "${previous}" ]; then

--- a/docs/release-notes/8.1.7.md
+++ b/docs/release-notes/8.1.7.md
@@ -1,0 +1,46 @@
+## What's changed
+
+First release under the `FFmpegKit.Net.*` package IDs, and the first built on FFmpegKit **8.1.7** — the previous packages shipped FFmpegKit 4.5. If you are coming from `Xamarin.FFmpegKit.*`, read the breaking changes below before upgrading: two of them can break an app at runtime rather than at compile time.
+
+## ⚠️ Breaking changes
+
+**Package IDs have changed.** `Xamarin.FFmpegKit.<Variant>.Android` is replaced by `FFmpegKit.Net.<Variant>.Android` and is no longer published.
+
+```diff
+-<PackageReference Include="Xamarin.FFmpegKit.Video.Android" Version="4.5.1" />
++<PackageReference Include="FFmpegKit.Net.Video.Android" Version="8.1.7" />
+```
+
+The `Ffmpegkit.Droid` namespace is **unchanged**, so your `using` directives and call sites stay exactly as they are. The namespace deliberately does not follow the package name: a namespace rooted at `FFmpegKit` containing a type also called `FFmpegKit` would make `FFmpegKit.Execute(...)` resolve the namespace instead of the class and fail to compile. The assembly is now `FFmpegKit.Net.<Variant>.Android`, which only matters if you reference it by assembly name or via reflection.
+
+**32-bit ABIs are gone.** The 4.5.1 packages carried `armeabi-v7a`, `arm64-v8a`, `x86` and `x86_64`. The 8.1.7 binaries ship **`arm64-v8a` and `x86_64` only**. An app that still serves 32-bit devices — or an x86 emulator image — will install and then fail when the native library loads. Check your device matrix before upgrading.
+
+**Minimum Android version is now API 24** (Android 7.0), as required by the native `.aar`.
+
+**Licence metadata has been corrected.** The old packages declared `MIT`, which was wrong: they embedded copyleft native binaries. Packages now declare what they actually contain:
+
+- non-GPL variants → `MIT AND LGPL-3.0-only`
+- `-gpl` variants → `MIT AND GPL-3.0-only`
+
+Your obligations have not changed — the metadata was simply inaccurate before. If you ship a `-gpl` variant in a closed-source app, review that now; upstream's guidance is to use a non-GPL variant. Each package ships the applicable texts under `licenses/`.
+
+**FFmpeg itself jumped from 4.5 to 8.1.7.** Expect upstream FFmpeg behaviour changes across four major versions — filter syntax, defaults and codec availability may differ from what your commands relied on.
+
+## Target frameworks
+
+Packages now target `net8.0-android34.0`, `net9.0-android35.0` and `net10.0-android36.0`, replacing the classic Xamarin `MonoAndroid10` assets. .NET MAUI and .NET for Android projects consume them directly.
+
+## Native binaries
+
+The original `arthenica/ffmpeg-kit` is archived and its release assets were deleted; its official continuation `arthenica/ffmpeg-kit-next` publishes source only, with no binary assets in any release. The `.aar` files therefore come from the actively maintained community fork [`ffmpegkit-maintained/ffmpeg`](https://github.com/ffmpegkit-maintained/ffmpeg), published to Maven Central as `dev.ffmpegkit-maintained`.
+
+It keeps the original `com.arthenica.ffmpegkit` Java API, so the binding surface is unaffected by the switch. The binding also now exposes the full 8.1.7 API, including `WhisperKit` and the translation providers.
+
+## Fixes
+
+- `FFmpegKitConfig`'s static initialiser calls `com.arthenica.smartexception.java.Exceptions`, which upstream neither bundles in the `.aar` nor declares in its `.pom`. Those classes are now embedded, so FFmpeg calls no longer fail with `NoClassDefFoundError` on device.
+- Packages carry a real binding assembly for every advertised target framework. An unpinned Android API level previously produced a valid-but-empty assembly that installed cleanly and exposed nothing.
+
+## Under the hood
+
+The binding moved from a classic Xamarin project to an SDK-style, multi-targeted one, packed with `dotnet pack` instead of hand-maintained `.nuspec` files. Every release is now gated on package-content tests and on-device smoke tests that run real FFmpeg commands on an emulator, and is published to nuget.org through Trusted Publishing (OIDC) rather than a long-lived API key.


### PR DESCRIPTION
Introduces a mechanism to use hand-written Markdown files from `docs/release-notes/` as the content for GitHub release descriptions. This allows for comprehensive, human-readable changelogs for significant versions, replacing the default `git log` output.

This commit also adds the first set of these curated notes for version 8.1.7, detailing critical breaking changes, new target frameworks, native binary sources, and other important updates.