### PR TITLE
Build the sample app in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,6 +128,46 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  sample:
+    name: build sample app
+    needs: pack
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Install MAUI workload
+        run: dotnet workload install maui-android
+
+      - name: Set up Android SDK platforms
+        uses: android-actions/setup-android@v3
+        with:
+          packages: 'platforms;android-35'
+
+      - name: Download packages
+        uses: actions/download-artifact@v4
+        with:
+          name: nuget-packages
+          path: artifacts
+
+      # The sample consumes the packed package through a PackageReference exactly as a user
+      # would, so it is the only thing here that checks the API is still usable the way the
+      # README documents it. It has regressed silently twice: once when a renamed property left
+      # it referring to something that no longer existed, and once when it resolved a published
+      # package from nuget.org instead of the one just built, because its version property
+      # pointed at the wrong number. Nothing built it, so nothing noticed.
+      #
+      # Build only - the device tests already prove the binding runs.
+      - name: Build the sample against the packed package
+        run: |
+          dotnet build FFmpegKit.Android.Example/FFmpegKit.Android.Example.csproj \
+            --configuration Release \
+            -p:FFmpegKitVersion="${{ inputs.version }}"
+
   e2e:
     name: emulator smoke test
     needs: pack

--- a/README.md
+++ b/README.md
@@ -283,7 +283,9 @@ It references the `Full` (LGPL) variant deliberately — swapping to a `-gpl` on
 
 The sample targets API 26 rather than the package's own floor of 24, because it previews results with CommunityToolkit's `MediaElement`, which requires 26. Your own app can still target 24.
 
-The app is intentionally **not** part of `FFmpegKit.sln` and not built in CI: it needs the MAUI workload, which would add several minutes to every run while proving less than the device tests already do.
+CI builds it on every pull request and release, against the package produced by that same run. It consumes the package through a `PackageReference` exactly as you would, so it is what catches an API that no longer matches the documentation here — it is only built, never deployed, since the device tests already prove the binding runs.
+
+It is deliberately **not** in `FFmpegKit.sln`, so that `dotnet build FFmpegKit.sln` does not require the MAUI workload.
 
 ## CI
 


### PR DESCRIPTION
The sample is the only thing here that consumes the package through a PackageReference the way a user does, so it is what catches an API that no longer matches what the README documents. Nothing built it, and it regressed silently twice: once referring to a member that had been renamed, and once resolving a published package from nuget.org instead of the one just built, because its version property pointed at the fork's release number rather than the FFmpeg version.

Mirrors the sample job in FFmpegKit.iOS: build only, in parallel with the emulator job, since the device tests already prove the binding runs. The MAUI workload install is the cost, and it overlaps the e2e job rather than extending the critical path.

Still kept out of FFmpegKit.sln so that building the solution does not require the MAUI workload.